### PR TITLE
adds Dockerfile, can add a PR later for publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:latest AS builder
+WORKDIR /app
+
+COPY . /app/
+RUN cargo build --release
+
+RUN strip target/release/edgelinkd
+RUN mkdir /export && \
+  cp $(ldd /app/target/release/edgelinkd | grep -ve 'libc\.so' -e 'ld-linux' -e 'vdso\.so' | sed -e s/'.*=> '// -e s/' (0x.*'//) /export
+
+FROM debian:bookworm-slim as release
+WORKDIR /app
+COPY --from=builder /app/target/release/edgelinkd .
+COPY --from=builder /export /usr/local/lib
+RUN ldconfig
+EXPOSE 1888
+
+CMD ["./edgelinkd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM rust:latest AS builder
+RUN apt update && apt install -y nodejs npm
 WORKDIR /app
 
 COPY . /app/
-RUN cargo build --release
+RUN --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    cargo build --release --all-targets
 
-RUN strip target/release/edgelinkd
+RUN strip /app/target/release/edgelinkd
 RUN mkdir /export && \
   cp $(ldd /app/target/release/edgelinkd | grep -ve 'libc\.so' -e 'ld-linux' -e 'vdso\.so' | sed -e s/'.*=> '// -e s/' (0x.*'//) /export
 
 FROM debian:bookworm-slim as release
+RUN mkdir -p /app/target/
 WORKDIR /app
 COPY --from=builder /app/target/release/edgelinkd .
+COPY --from=builder /app/target/ui_static /app/target/ui_static 
 COPY --from=builder /export /usr/local/lib
 RUN ldconfig
 EXPOSE 1888


### PR DESCRIPTION
Dockerfile that creates a simple clean debian-based container, grabbing the libraries needed using ldd.

If you like I can craft a github action that adds a build and publish to ghcr.io (github container registry), so people can pull the docker image and just use it.

Also I can probably contribute a helm chart for kubernetes :-)